### PR TITLE
Made the Viewport stateless.

### DIFF
--- a/client/src/components/viewport.rs
+++ b/client/src/components/viewport.rs
@@ -53,22 +53,22 @@ impl Component for Viewport {
 
     fn changed(&mut self, ctx: &Context<Self>, _old_props: &Self::Properties) -> bool {
         self.headset.set_streams(&ctx.props().streams);
-        true
+        false
     }
 
     fn rendered(&mut self, _ctx: &Context<Self>, first_render: bool) {
-        let left = self.left_ref.cast().unwrap();
-        let right = self.right_ref.cast().unwrap();
-
         if first_render {
+            let left = self.left_ref.cast().unwrap();
+            let right = self.right_ref.cast().unwrap();
+
             let track = self.track.clone();
             let closure = Closure::new(move |value| track.send(value));
             setup_3d(self.canvas_ref.cast().unwrap(), &left, &right, &closure);
             closure.forget();
-        }
 
-        left.set_src_object(self.headset.left_viewport());
-        right.set_src_object(self.headset.right_viewport());
+            left.set_src_object(self.headset.left_viewport());
+            right.set_src_object(self.headset.right_viewport());
+        }
     }
 }
 

--- a/client/src/headset.rs
+++ b/client/src/headset.rs
@@ -1,23 +1,41 @@
+use wasm_bindgen::JsCast;
 use web_sys::MediaStream;
 
 pub struct Wrapper {
-    streams: Option<(MediaStream, MediaStream)>,
+    left: MediaStream,
+    right: MediaStream,
 }
 
 impl Wrapper {
     pub fn new() -> Wrapper {
-        Wrapper { streams: None }
+        Wrapper {
+            left: MediaStream::new().unwrap(),
+            right: MediaStream::new().unwrap(),
+        }
     }
 
     pub fn set_streams(&mut self, streams: &Option<(MediaStream, MediaStream)>) {
-        self.streams = streams.clone();
+        for track in self.left.get_tracks().iter() {
+            self.left.remove_track(track.dyn_ref().unwrap())
+        }
+        for track in self.right.get_tracks().iter() {
+            self.right.remove_track(track.dyn_ref().unwrap())
+        }
+        if let Some((new_left, new_right)) = streams {
+            for track in new_left.get_tracks().iter() {
+                self.left.add_track(track.dyn_ref().unwrap())
+            }
+            for track in new_right.get_tracks().iter() {
+                self.right.add_track(track.dyn_ref().unwrap())
+            }
+        }
     }
 
     pub fn left_viewport(&self) -> Option<&MediaStream> {
-        self.streams.as_ref().map(|s| &s.0)
+        Some(&self.left)
     }
 
     pub fn right_viewport(&self) -> Option<&MediaStream> {
-        self.streams.as_ref().map(|s| &s.1)
+        Some(&self.right)
     }
 }


### PR DESCRIPTION
When you set new MediaStream to the headset only tracks are copied over. This makes it so that the Viewport Component do not need to know when a stream starts or stops.